### PR TITLE
[render preview] feat: submission status-tag explainer

### DIFF
--- a/src/features/sponsor-dashboard/components/Submissions/Details.tsx
+++ b/src/features/sponsor-dashboard/components/Submissions/Details.tsx
@@ -19,6 +19,7 @@ import { type Listing } from '@/features/listings/types';
 import { selectedSubmissionAtom } from '../../atoms';
 import { InfoBox, parseHtml } from '../InfoBox';
 import { Notes } from './Notes';
+import SubmissionStatusExplanation from './SubmissionStatusExplainer';
 
 interface Props {
   bounty: Listing | undefined;
@@ -75,6 +76,9 @@ export const Details = ({ bounty, externalView, atom }: Props) => {
           externalView ? 'mt-3' : 'overflow-y-auto p-4',
         )}
       >
+        <div className="mb-4">
+          <SubmissionStatusExplanation submission={selectedSubmission} />
+        </div>
         {bounty?.compensationType !== 'fixed' && (
           <div className="mb-4">
             <p className="mt-1 text-xs font-semibold uppercase text-slate-400">

--- a/src/features/sponsor-dashboard/components/Submissions/SubmissionStatusExplainer.tsx
+++ b/src/features/sponsor-dashboard/components/Submissions/SubmissionStatusExplainer.tsx
@@ -1,0 +1,96 @@
+import { type SubmissionWithUser } from '@/interface/submission';
+
+import { sponsorshipSubmissionStatus } from '@/features/listings/components/SubmissionsPage/SubmissionTable';
+import { colorMap } from '@/features/sponsor-dashboard/utils/statusColorMap';
+
+const statusExplanation = (
+  status: ReturnType<typeof sponsorshipSubmissionStatus>,
+) => {
+  switch (status) {
+    case 'Paid':
+      return {
+        final: true,
+      };
+    case 'Approved':
+      return {
+        waitingForPayment: true,
+      };
+    case 'Rejected':
+      return {
+        final: true,
+      };
+    case 'Spam':
+      return {
+        blocked: true,
+      };
+    case 'Reviewed':
+      return {
+        locked: true,
+        waitingForSponsor: true,
+      };
+    case 'Shortlisted':
+      return {
+        waitingForSponsor: true,
+        locked: true,
+      };
+    case 'Unreviewed':
+      return {
+        waitingForSponsor: true,
+        editable: true,
+      };
+  }
+};
+export default function SubmissionStatusExplanation({
+  submission,
+}: {
+  submission: SubmissionWithUser | undefined;
+}) {
+  if (!submission) return null;
+
+  const sponsorshipStatus = sponsorshipSubmissionStatus(submission);
+  const explanation = statusExplanation(sponsorshipStatus);
+  const statusColors = colorMap[sponsorshipStatus as keyof typeof colorMap];
+
+  return (
+    <div className="flex w-full">
+      <div
+        className={`w-full rounded-lg p-4 ${statusColors.bg} ${statusColors.color}`}
+      >
+        <div className="flex flex-col space-y-2">
+          <h3 className="text-sm font-semibold">Status: {sponsorshipStatus}</h3>
+          <ul className="list-inside list-disc space-y-1 text-sm">
+            {explanation.waitingForSponsor && (
+              <li>The sponsor action is required</li>
+            )}
+            {explanation.waitingForPayment && (
+              <li>
+                The submission is waiting for the sponsor to pay the recipient
+              </li>
+            )}
+            {explanation.editable && (
+              <li>The submission can be edited by the submitter</li>
+            )}
+            {explanation.locked && (
+              <li>The submission is locked and cannot be edited</li>
+            )}
+            {explanation.final && (
+              <>
+                <li>The submission has reached its final state</li>
+                <li>The submitter can create a new submission</li>
+              </>
+            )}
+            {explanation.blocked && (
+              <>
+                <li>The submission has been marked as spam</li>
+                <li>
+                  The submitter blocked from creating new submissions to this
+                  listing
+                </li>
+              </>
+            )}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Added banners explaining the current submission status

![image](https://github.com/user-attachments/assets/5d21f2f9-15c7-42c4-b571-6d52a57a72db)
![image](https://github.com/user-attachments/assets/d199b81f-d535-4a01-b7bb-438e23765369)
![image](https://github.com/user-attachments/assets/e761cbe5-4a86-4c3d-b1ab-3eaf795723fb)

@race-of-sloths