### PR TITLE
Update env to single database variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,20 +1,52 @@
-# database configuration
-
-# option 1: Local MySQL Database
-# use this if you're running a local MySQL instance
-# format: mysql://USER:PASSWORD@HOST:PORT/DATABASE
-LOCAL_DATABASE_URL=''
-
-# option 2: PlanetScale Database
-# use this if you're connecting to PlanetScale
-# format: mysql://USERNAME:PASSWORD@HOST/DATABASE_NAME?sslaccept=strict
+# Database configuration
+# Format: mysql://USERNAME:PASSWORD@HOST/DATABASE_NAME?sslaccept=strict
 DATABASE_URL=''
 
-RESEND_API_KEY= ''
-RESEND_EMAIL= 'onboarding@resend.dev'
+# Server configuration
+PORT=3000
+NEXTAUTH_URL='http://localhost:3000'
+NEXTAUTH_SECRET=''
 
+# Public URLs
+NEXT_PUBLIC_URL='http://localhost:3000'
+NEXT_PUBLIC_SITE_URL='http://localhost:3000'
+NEXT_PUBLIC_BASE_URL='http://localhost:3000'
+NEXT_PUBLIC_RPC_URL=''
+NEXT_PUBLIC_GA_TRACKING_ID=''
+
+# Resend email configuration
+RESEND_API_KEY=''
+RESEND_EMAIL='onboarding@resend.dev'
 EMAIL_SERVER_USER='resend'
 EMAIL_SERVER_HOST='smtp.resend.com'
 EMAIL_SERVER_PORT='465'
 
-NEXTAUTH_SECRET= ''
+# Misc services
+ZEROBOUNCE_API_KEY=''
+AIRTABLE_GRANTS_API_TOKEN=''
+AIRTABLE_GRANTS_BASE_ID=''
+AIRTABLE_GRANTS_TABLE_NAME=''
+AIRTABLE_GRANTS_REGIONS_TABLE_NAME=''
+AIRTABLE_RECIPIENTS_TABLE=''
+AIRTABLE_GDP_API_TOKEN=''
+AIRTABLE_GDP_BASE_ID=''
+AIRTABLE_GDP_SPONSORS_TABLE_NAME=''
+CLOUDINARY_CLOUD_NAME=''
+CLOUDINARY_API_KEY=''
+CLOUDINARY_API_SECRET=''
+CLOUDINARY_SUBMISSIONS_FOLDER=''
+EARNCOGNITO_URL=''
+EARNCOGNITO_SECRET=''
+GOOGLE_ID=''
+GOOGLE_SECRET=''
+EMAIL_SECRET=''
+EMAIL_BACKEND=''
+NEXT_PUBLIC_POSTHOG_HOST=''
+NEXT_PUBLIC_POSTHOG_KEY=''
+REPLY_TO_EMAIL=''
+WEBHOOK_SECRET=''
+UNSUB_SECRET=''
+CEO_EMAIL=''
+
+# Logging
+LOG_LEVEL=''

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,13 +16,10 @@
   - Start by copying the `.env.example` file to a new file named `.env`. This file will store your local environment settings.
   - Use `openssl rand -base64 32` to generate a key and add it under `NEXTAUTH_SECRET` in the .env file.
   - Database setup
-    - Create a local `MySQL` instance and replace `<user>`, `<pass>`, `<db-host>`, and `<db-port>` with their applicable values.
+    - Set the `DATABASE_URL` environment variable with your MySQL connection string. Services like railway.app or Render can help you host a database if you don't run one locally.
       ```
-      LOCAL_DATABASE_URL='mysql://<user>:<pass>@<db-host>:<db-port>'
-      ``` 
-    - If you don't want to create a local DB, then you can also consider using services like railway.app or render.
-      - [Setup MySQL DB with railway.app](https://docs.railway.app/guides/mysql)
-      - [Setup MYSQL DB with render](https://docs.render.com/deploy-mysql)
+      DATABASE_URL='mysql://<user>:<pass>@<db-host>:<db-port>/<database>?sslaccept=strict'
+      ```
 
     - Generate prisma migrations & client.
       ```bash

--- a/README.md
+++ b/README.md
@@ -40,13 +40,10 @@
   - Start by copying the `.env.example` file to a new file named `.env`. This file will store your local environment settings.
   - Use `openssl rand -base64 32` to generate a key and add it under `NEXTAUTH_SECRET` in the .env file.
   - Database setup
-    - Create a local `MySQL` instance and replace `<user>`, `<pass>`, `<db-host>`, and `<db-port>` with their applicable values.
+    - Set the `DATABASE_URL` environment variable with your MySQL connection string. Services like railway.app or Render can help you host a database if you don't run one locally.
       ```
-      LOCAL_DATABASE_URL='mysql://<user>:<pass>@<db-host>:<db-port>'
-      ``` 
-    - If you don't want to create a local DB, then you can also consider using services like railway.app or render.
-      - [Setup MySQL DB with railway.app](https://docs.railway.app/guides/mysql)
-      - [Setup MYSQL DB with render](https://docs.render.com/deploy-mysql)
+      DATABASE_URL='mysql://<user>:<pass>@<db-host>:<db-port>/<database>?sslaccept=strict'
+      ```
       
     - Generate prisma migrations & client.
       ```bash

--- a/src/prisma.ts
+++ b/src/prisma.ts
@@ -1,13 +1,9 @@
 import { PrismaClient } from '@prisma/client';
 
 const prismaClient = () => {
-  return process.env.DATABASE_URL
-    ? new PrismaClient({
-        datasourceUrl: process.env.DATABASE_URL,
-      })
-    : new PrismaClient({
-        datasourceUrl: process.env.LOCAL_DATABASE_URL,
-      });
+  return new PrismaClient({
+    datasourceUrl: process.env.DATABASE_URL,
+  });
 };
 
 declare const globalThis: {


### PR DESCRIPTION
## Summary
- drop `LOCAL_DATABASE_URL` from env and docs
- point README and CONTRIBUTING instructions to `DATABASE_URL`
- simplify Prisma client creation to use just `DATABASE_URL`

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402081347c832780dd5c9a5c47f184