### PR TITLE
Add MySQL docker for local setup and fix forwardRef error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Database configuration
-# Format: mysql://USERNAME:PASSWORD@HOST/DATABASE_NAME?sslaccept=strict
-DATABASE_URL=''
+# Production Format: mysql://USERNAME:PASSWORD@HOST/DATABASE_NAME?sslaccept=strict
+DATABASE_URL='mysql://root:nearn_root_password@localhost:3306/nearn_dev'
 
 # Server configuration
 PORT=3000

--- a/README.md
+++ b/README.md
@@ -22,48 +22,57 @@
 ### Getting Started
 
 1. Clone the repository into a public Github repository (or fork it):
+
     ```bash
     git clone https://github.com/NEAR-DevHub/nearn.git
     ```
 
 2. Navigate to the project directory:
+
     ```bash
     cd nearn
     ```
 
-3. Install the dependencies: 
+3. Install the dependencies:
+
     ```bash
     pnpm i
     ```
 
 4. Set up your `.env` file.
-  - Start by copying the `.env.example` file to a new file named `.env`. This file will store your local environment settings.
-  - Use `openssl rand -base64 32` to generate a key and add it under `NEXTAUTH_SECRET` in the .env file.
-  - Database setup
-    - Set the `DATABASE_URL` environment variable with your MySQL connection string. Services like railway.app or Render can help you host a database if you don't run one locally.
+
+- Start by copying the `.env.example` file to a new file named `.env`. This file will store your local environment settings.
+- Use `openssl rand -base64 32` to generate a key and add it under `NEXTAUTH_SECRET` in the .env file.
+- Database setup
+  - Set the `DATABASE_URL` environment variable with your MySQL connection string. Services like railway.app or Render can help you host a database if you don't run one locally. You can run `docker compose up -d` and use the default connection string for local development.
+
       ```
       DATABASE_URL='mysql://<user>:<pass>@<db-host>:<db-port>/<database>?sslaccept=strict'
       ```
-      
-    - Generate prisma migrations & client.
+
+  - Generate prisma migrations & client.
+
       ```bash
       npx prisma migrate dev --name init && npx prisma generate
       ```
 
-  - You have to set up resend to run the app:
-    - [Resend](https://resend.com): To obtain your `RESEND_API_KEY`, visit the Resend dashboard. This credential is essential for setting up Email Auth.
+- You have to set up resend to run the app:
+  - [Resend](https://resend.com): To obtain your `RESEND_API_KEY`, visit the Resend dashboard. This credential is essential for setting up Email Auth.
 
   NOTE: If you are facing any issues with setup, please create an issue and we will try to help you out.
 
 5. Run the development server
+
     ```bash
     pnpm dev
     ```
 
 ## Contributing
+
 We welcome contributions from everyone! Whether it's submitting an issue, a pull request, or suggesting new ideas, your input is highly valued. Check out our [contributing guide](CONTRIBUTING.md) for guidelines on how to proceed.
 
 ### Contributors
+
 <a href="https://github.com/NEAR-DevHub/nearn/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=NEAR-DevHub/nearn" />
 </a>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: nearn_mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: nearn_root_password
+      MYSQL_DATABASE: nearn_dev
+      MYSQL_USER: nearn_user
+      MYSQL_PASSWORD: nearn_password
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+      - ./docker/mysql/init:/docker-entrypoint-initdb.d
+    command: --default-authentication-plugin=mysql_native_password
+
+volumes:
+  mysql_data:
+    driver: local

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -32,14 +32,10 @@ const TooltipContent = React.forwardRef<
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 
 const Tooltip = React.forwardRef<HTMLButtonElement, TooltipProps>(
-  ({
-    children,
-    content,
-    contentProps,
-    triggerClassName,
-    disabled,
-    ...props
-  }) => {
+  (
+    { children, content, contentProps, triggerClassName, disabled, ...props },
+    ref,
+  ) => {
     const [open, setOpen] = React.useState(false);
 
     if (disabled) {
@@ -51,6 +47,7 @@ const Tooltip = React.forwardRef<HTMLButtonElement, TooltipProps>(
         <TooltipPrimitive.Root open={open} {...props}>
           <TooltipPrimitive.Trigger asChild>
             <button
+              ref={ref}
               type="button"
               className={cn('cursor-pointer', triggerClassName)}
               onClick={() => setOpen(!open)}


### PR DESCRIPTION
These are modifications I needed in order for the repository to run.

- [x] adds docker compose with MySQL image and updates README to reference it
- [x] fixes "forwardRef render functions accept exactly two parameters: props and ref." error