### PR TITLE
bugfix: fix debounce for save draft functionality

### DIFF
--- a/src/features/listing-builder/atoms/index.ts
+++ b/src/features/listing-builder/atoms/index.ts
@@ -20,15 +20,6 @@ const descriptionKeyAtom = atom<string | number>(1);
 const skillsKeyAtom = atom<string | number>(1);
 const isListingInReviewAtom = atom<boolean>(false);
 
-interface SaveQueueState {
-  isProcessing: boolean;
-  shouldProcessNext: boolean;
-}
-const draftQueueAtom = atom<SaveQueueState>({
-  isProcessing: false,
-  shouldProcessNext: false,
-});
-
 const confirmModalAtom = atom<'SUCCESS' | 'VERIFICATION' | undefined>(
   undefined,
 );
@@ -62,7 +53,6 @@ const submitListingMutationAtom = atomWithMutation((get) => ({
 export {
   confirmModalAtom,
   descriptionKeyAtom,
-  draftQueueAtom,
   hackathonsAtom,
   hideAutoSaveAtom,
   isDraftSavingAtom,

--- a/src/features/listing-builder/components/ListingBuilderProvider.tsx
+++ b/src/features/listing-builder/components/ListingBuilderProvider.tsx
@@ -17,7 +17,6 @@ import { Header } from '@/features/navbar/components/Header';
 
 import {
   confirmModalAtom,
-  draftQueueAtom,
   hackathonsAtom,
   isEditingAtom,
   isGodAtom,
@@ -186,13 +185,6 @@ function ListingBuilderProvider({
           [
             isListingInReviewAtom,
             isEditing && listing && dayjs().isAfter(listing.deadline),
-          ],
-          [
-            draftQueueAtom,
-            {
-              isProcessing: false,
-              shouldProcessNext: false,
-            },
           ],
         ]}
       >

--- a/src/features/listing-builder/hooks/index.ts
+++ b/src/features/listing-builder/hooks/index.ts
@@ -11,7 +11,6 @@ import { dayjs } from '@/utils/dayjs';
 
 import {
   descriptionKeyAtom,
-  draftQueueAtom,
   hackathonsAtom,
   hideAutoSaveAtom,
   isDraftSavingAtom,
@@ -29,6 +28,13 @@ import {
   createListingRefinements,
 } from '../types/schema';
 import { getListingDefaults, refineReadyListing } from '../utils/form';
+
+const formatDraftData = (data: Partial<ListingFormData>) => {
+  if (data.deadline) {
+    if (!data.deadline.endsWith('Z')) data.deadline += dayjs().format('Z');
+  }
+  return data;
+};
 
 interface UseListingFormReturn extends UseFormReturn<ListingFormData> {
   saveDraft: () => void;
@@ -87,62 +93,22 @@ export const useListingForm = (
   const saveDraftMutation = useAtomValue(saveDraftMutationAtom);
   const submitListingMutation = useAtomValue(submitListingMutationAtom);
   const [, setDraftSaving] = useAtom(isDraftSavingAtom);
-
-  const [queueRef, setQueueRef] = useAtom(draftQueueAtom);
-
   const [, setHideAutoSave] = useAtom(hideAutoSaveAtom);
-  const queueRefRef = useRef(queueRef);
 
-  useEffect(() => {
-    queueRefRef.current = queueRef;
-  }, [queueRef]);
-
-  // queue ensures eeach call for auto save is sent synchronously
-  const processSaveQueue = useCallback(async () => {
+  const saveDraft = useCallback(async () => {
     if (isEditing) return;
     setDraftSaving(true);
-    if (queueRefRef.current.isProcessing) {
-      setQueueRef((q) => ({
-        ...q,
-        shouldProcessNext: true,
-      }));
-      return;
-    }
-
-    setQueueRef((q) => ({
-      ...q,
-      shouldProcessNext: false,
-      isProcessing: true,
-    }));
     try {
-      const dataToSave = getValues();
-
-      if (dataToSave.deadline) {
-        if (!dataToSave.deadline.endsWith('Z'))
-          dataToSave.deadline += dayjs().format('Z');
-      }
+      const listingData = getValues();
+      const dataToSave = formatDraftData(listingData);
       const data = await saveDraftMutation.mutateAsync(dataToSave);
       setHideAutoSave(false);
       formMethods.setValue('id', data.id);
       if (!dataToSave.slug) formMethods.setValue('slug', data.slug);
-      setQueueRef((q) => ({
-        ...q,
-      }));
     } catch (error) {
-      console.log('Error processSaveQueue', error);
+      console.log('Error saving draft', error);
     } finally {
       setDraftSaving(false);
-      setQueueRef((q) => ({
-        ...q,
-        isProcessing: false,
-      }));
-      // Check if we need to process another save
-      if (queueRefRef.current.shouldProcessNext) {
-        // Use setTimeout to break the call stack and ensure queue state is updated
-        setTimeout(() => {
-          void processSaveQueue();
-        }, 0);
-      }
     }
   }, [
     getValues,
@@ -153,19 +119,21 @@ export const useListingForm = (
     isEditing,
   ]);
 
-  const debouncedSaveRef = useRef<ReturnType<typeof debounce>>(undefined);
-
+  const latestSaveDraftRef = useRef<() => void>(saveDraft);
   useEffect(() => {
-    debouncedSaveRef.current = debounce(() => {
-      void processSaveQueue();
-    }, 1000);
-  }, [processSaveQueue]);
+    latestSaveDraftRef.current = saveDraft;
+  }, [saveDraft]);
+
+  const debouncedRef = useRef<ReturnType<typeof debounce> | null>(null);
+  useEffect(() => {
+    debouncedRef.current = debounce(latestSaveDraftRef.current, 1000);
+    return () => debouncedRef.current?.cancel();
+  }, []);
 
   const onChange = useCallback(() => {
     setHideAutoSave(true);
     if (!isEditing) {
-      debouncedSaveRef.current?.cancel();
-      debouncedSaveRef.current?.();
+      debouncedRef.current?.();
     }
   }, [isEditing]);
 


### PR DESCRIPTION
## What does this PR do?

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors draft autosave to a debounced flow (no queue), normalizes deadline formatting, and removes the now-unused draftQueue atom and hydration.
> 
> - **Listing Builder – Autosave**
>   - Replace save-queue logic with a simple debounced `saveDraft` using refs to keep latest callback; cancel debounce on unmount.
>   - Add `formatDraftData` to normalize `deadline` (append timezone if missing).
>   - Update `onChange` to trigger debounced save and manage `hideAutoSave`/`isDraftSaving` state.
> - **Atoms**
>   - Remove `draftQueueAtom` and related exports.
> - **Provider**
>   - Stop hydrating removed `draftQueueAtom`; no functional changes to other initial atoms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 639a770cc684bd006aa68774659a7469c47a3015. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->