### PR TITLE
feat: Extract milestone data into separate column from Ask

### DIFF
--- a/src/features/sponsor-dashboard/components/SubmissionTable.tsx
+++ b/src/features/sponsor-dashboard/components/SubmissionTable.tsx
@@ -335,7 +335,7 @@ export const SubmissionTable = ({
                           onClick={() => {
                             const newDirection =
                               currentSort.column === 'createdAt' &&
-                              currentSort.direction === 'asc'
+                                currentSort.direction === 'asc'
                                 ? 'desc'
                                 : 'asc';
                             onSort('createdAt', newDirection);
@@ -355,7 +355,7 @@ export const SubmissionTable = ({
                           onClick={() => {
                             const newDirection =
                               currentSort.column === 'approvedAt' &&
-                              currentSort.direction === 'asc'
+                                currentSort.direction === 'asc'
                                 ? 'desc'
                                 : 'asc';
                             onSort('approvedAt', newDirection);
@@ -375,7 +375,7 @@ export const SubmissionTable = ({
                           onClick={() => {
                             const newDirection =
                               currentSort.column === 'paidAt' &&
-                              currentSort.direction === 'asc'
+                                currentSort.direction === 'asc'
                                 ? 'desc'
                                 : 'asc';
                             onSort('paidAt', newDirection);
@@ -642,8 +642,8 @@ export const SubmissionTable = ({
                                   <DoneBy
                                     doneBy={
                                       submission?.approvedByUser as
-                                        | User
-                                        | undefined
+                                      | User
+                                      | undefined
                                     }
                                     doneByType="approved"
                                   />
@@ -745,45 +745,45 @@ export const SubmissionTable = ({
                             {(submission?.listing?.type === 'sponsorship' ||
                               (submission?.listing?.type === 'bounty' &&
                                 submission?.listing?.isWinnersAnnounced)) && (
-                              <>
-                                <DropdownMenuItem
-                                  className="cursor-pointer text-sm font-medium text-slate-500"
-                                  onClick={() => {
-                                    posthog.capture(
-                                      'sponsor_public_submission_view',
-                                    );
-                                    router.push(submissionLink);
-                                  }}
-                                >
-                                  <ExternalLink className="mr-2 h-4 w-4" />
-                                  View Public Submission
-                                </DropdownMenuItem>
+                                <>
+                                  <DropdownMenuItem
+                                    className="cursor-pointer text-sm font-medium text-slate-500"
+                                    onClick={() => {
+                                      posthog.capture(
+                                        'sponsor_public_submission_view',
+                                      );
+                                      router.push(submissionLink);
+                                    }}
+                                  >
+                                    <ExternalLink className="mr-2 h-4 w-4" />
+                                    View Public Submission
+                                  </DropdownMenuItem>
 
-                                <DropdownMenuItem
-                                  className="cursor-pointer text-sm font-medium text-slate-500"
-                                  onClick={() => {
-                                    copyToClipboard(submissionLink);
-                                  }}
-                                >
-                                  <Copy className="mr-2 h-4 w-4" />
-                                  Copy Link
-                                </DropdownMenuItem>
-                                {milestone?.status === 'Paid' &&
-                                  milestone?.paymentDetails?.link && (
-                                    <DropdownMenuItem
-                                      className="cursor-pointer text-sm font-medium text-slate-500"
-                                      onClick={() => {
-                                        copyToClipboard(
-                                          milestone?.paymentDetails?.link || '',
-                                        );
-                                      }}
-                                    >
-                                      <Copy className="mr-2 h-4 w-4" />
-                                      Copy Payment Link
-                                    </DropdownMenuItem>
-                                  )}
-                              </>
-                            )}
+                                  <DropdownMenuItem
+                                    className="cursor-pointer text-sm font-medium text-slate-500"
+                                    onClick={() => {
+                                      copyToClipboard(submissionLink);
+                                    }}
+                                  >
+                                    <Copy className="mr-2 h-4 w-4" />
+                                    Copy Link
+                                  </DropdownMenuItem>
+                                  {milestone?.status === 'Paid' &&
+                                    milestone?.paymentDetails?.link && (
+                                      <DropdownMenuItem
+                                        className="cursor-pointer text-sm font-medium text-slate-500"
+                                        onClick={() => {
+                                          copyToClipboard(
+                                            milestone?.paymentDetails?.link || '',
+                                          );
+                                        }}
+                                      >
+                                        <Copy className="mr-2 h-4 w-4" />
+                                        Copy Payment Link
+                                      </DropdownMenuItem>
+                                    )}
+                                </>
+                              )}
                             {isGodUser && submission.listing.isActive && (
                               <>
                                 {!submission.isArchived && (
@@ -811,7 +811,7 @@ export const SubmissionTable = ({
                                   }}
                                 >
                                   {submission.isArchived ||
-                                  !submission.isActive ? (
+                                    !submission.isActive ? (
                                     <>
                                       <RefreshCw className="mr-2 h-4 w-4" />
                                       Restore Submission
@@ -835,7 +835,7 @@ export const SubmissionTable = ({
                           const milestoneStatus = getMilestoneStatus(milestone);
                           const statusStyle =
                             colorMap[
-                              milestoneStatus as keyof typeof colorMap
+                            milestoneStatus as keyof typeof colorMap
                             ] || colorMap.NotStarted;
 
                           return (
@@ -871,8 +871,8 @@ export const SubmissionTable = ({
                                       {isUsdBased && '$'}
                                       {milestone.reward
                                         ? milestone.reward.toLocaleString(
-                                            'en-us',
-                                          )
+                                          'en-us',
+                                        )
                                         : '0'}
                                       <span className="text-slate-400">
                                         {isUsdBased && ' to be paid in'}
@@ -881,7 +881,7 @@ export const SubmissionTable = ({
                                         className={cn(
                                           'ml-1',
                                           !isUsdBased &&
-                                            'font-semibold text-slate-400',
+                                          'font-semibold text-slate-400',
                                         )}
                                       >
                                         {milestone.token}
@@ -1048,8 +1048,8 @@ export const SubmissionTable = ({
           editMode={true}
           listing={interactedSubmission.listing}
           isGodMode={isGodUser}
-          showEasterEgg={() => {}}
-          onSurveyOpen={() => {}}
+          showEasterEgg={() => { }}
+          onSurveyOpen={() => { }}
         />
       )}
     </>

--- a/src/features/sponsor-dashboard/components/SubmissionTable.tsx
+++ b/src/features/sponsor-dashboard/components/SubmissionTable.tsx
@@ -100,6 +100,7 @@ type ColumnKey =
   | 'contributor'
   | 'title'
   | 'ask'
+  | 'milestones'
   | 'status'
   | 'dates'
   | 'notes'
@@ -109,6 +110,7 @@ const columnLabels: Record<ColumnKey, string> = {
   contributor: 'Contributor',
   title: 'Listing Name',
   ask: 'Ask',
+  milestones: 'Milestones',
   status: 'Status',
   dates: 'Dates',
   notes: 'Notes',
@@ -188,6 +190,7 @@ export const SubmissionTable = ({
     contributor: true,
     title: true,
     ask: true,
+    milestones: true,
     status: true,
     dates: true,
     notes: false,
@@ -298,6 +301,9 @@ export const SubmissionTable = ({
                 </>
               )}
               {visibleColumns.ask && <SubmissionTh>Ask</SubmissionTh>}
+              {visibleColumns.milestones && (
+                <SubmissionTh>Milestones</SubmissionTh>
+              )}
               {visibleColumns.status && (
                 <SortableTH
                   column="status"
@@ -535,7 +541,7 @@ export const SubmissionTable = ({
                       )}
                       {visibleColumns.ask && (
                         <TableCell
-                          className="min-w-[250px] cursor-pointer pr-10 font-medium text-slate-700"
+                          className="cursor-pointer font-medium text-slate-700"
                           onClick={(e) => handleClick(e, listingSubmissionLink)}
                           onAuxClick={(e) =>
                             handleClick(e, listingSubmissionLink)
@@ -563,11 +569,37 @@ export const SubmissionTable = ({
                               </span>
                             </span>
                           </div>
-                          {submission.Milestones.length > 1 && (
-                            <MilestoneCompletionLine
-                              submission={submission}
-                              hideText={true}
-                            />
+                        </TableCell>
+                      )}
+                      {visibleColumns.milestones && (
+                        <TableCell
+                          className="min-w-[180px] cursor-pointer py-2 font-medium text-slate-700"
+                          onClick={(e) => handleClick(e, listingSubmissionLink)}
+                          onAuxClick={(e) =>
+                            handleClick(e, listingSubmissionLink)
+                          }
+                        >
+                          {submission.Milestones.length > 0 ? (
+                            <div className="flex flex-col gap-1">
+                              <p className="text-xs font-semibold text-slate-600">
+                                {
+                                  submission.Milestones.filter(
+                                    (m) =>
+                                      m.status === 'Paid' ||
+                                      m.status === 'Cancelled',
+                                  ).length
+                                }
+                                /{submission.Milestones.length} milestones
+                              </p>
+                              <MilestoneCompletionLine
+                                submission={submission}
+                                hideText={true}
+                              />
+                            </div>
+                          ) : (
+                            <span className="text-xs text-slate-400">
+                              No milestones
+                            </span>
                           )}
                         </TableCell>
                       )}
@@ -858,6 +890,7 @@ export const SubmissionTable = ({
                                   </div>
                                 </TableCell>
                               )}
+                              {visibleColumns.milestones && <TableCell />}
                               {visibleColumns.status && (
                                 <TableCell>
                                   <p

--- a/src/features/sponsor-dashboard/components/SubmissionTable.tsx
+++ b/src/features/sponsor-dashboard/components/SubmissionTable.tsx
@@ -49,7 +49,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@/components/ui/table';
+} from '@/components/ui/table'
 import { Tooltip } from '@/components/ui/tooltip';
 import { tokenList } from '@/constants/tokenList';
 import { useDisclosure } from '@/hooks/use-disclosure';


### PR DESCRIPTION
## Description

This PR addresses issue #536 by separating milestone information into its own dedicated column in the submissions table.

## Changes Made

- **Added new 'Milestones' column**: Created a dedicated column to display milestone progress separately from the Ask amount
- **Updated Ask column**: Now only displays the payment amount without milestone progress information
- **Milestone display improvements**: The new Milestones column shows:
  - Number of completed milestones vs total milestones (e.g., "1/2 milestones")
  - Visual progress bar showing milestone completion status
  - "No milestones" text when no milestones exist
- **Column visibility**: The Milestones column is visible by default and can be toggled like other columns

## UI Improvements

### Before:
- Ask column was cluttered with both payment amount and milestone progress
- Table looked overwhelming with too much information in one column

### After:
- Clean separation: Ask column shows only payment details
- Milestones column provides clear milestone progress visualization
- More organized and easier to scan

## Related Issue

Closes #536