### PR TITLE
deploy: added `title` as mandatory question for sponsorships

### DIFF
--- a/prisma/migrations/20251218131626_added_title_field_for_sponsorships/migration.sql
+++ b/prisma/migrations/20251218131626_added_title_field_for_sponsorships/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Submission` ADD COLUMN `title` VARCHAR(255) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -298,6 +298,7 @@ model Submission {
   updatedAt          DateTime         @updatedAt
   like               Json?
   likeCount          Int              @default(0)
+  title              String?          @db.VarChar(255)
   otherInfo          String?          @db.Text
   ask                Int?
   token              String?

--- a/src/components/eligibility/EligibilityQuestions.tsx
+++ b/src/components/eligibility/EligibilityQuestions.tsx
@@ -234,6 +234,29 @@ export function EligibilityQuestionsForm({
                 />
               </>
             )}
+            {listingType === 'sponsorship' && (
+              <FormField
+                control={control}
+                name={'title'}
+                render={({ field }) => (
+                  <FormItem className={cn('flex flex-col gap-2')}>
+                    <FormLabel isRequired>Title</FormLabel>
+                    <FormDescription>
+                      Please outline the main idea or name of your submission.
+                    </FormDescription>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        required
+                        placeholder="Add a title"
+                        maxLength={255}
+                      />
+                    </FormControl>
+                    <FormMessage className="pt-1" />
+                  </FormItem>
+                )}
+              />
+            )}
             {questions &&
               questions.map((e, index) => {
                 const fieldName = `eligibilityAnswers.${index}.answer` as const;

--- a/src/features/listings/components/Submission/SubmissionDrawer.tsx
+++ b/src/features/listings/components/Submission/SubmissionDrawer.tsx
@@ -160,11 +160,13 @@ export const SubmissionDrawer = ({
             ask,
             token,
             otherTokenDetails,
+            title,
           } = response.data;
 
           form.reset({
             link,
             tweet,
+            title,
             otherInfo,
             ask: ask || null,
             otherTokenDetails:
@@ -219,6 +221,7 @@ export const SubmissionDrawer = ({
         otherInfo: data.otherInfo || '',
         otherTokenDetails: data.otherTokenDetails || undefined,
         ask: data.ask || null,
+        title: data.title || '',
         eligibilityAnswers: data.eligibilityAnswers || [],
         publicKey: data.publicKey,
         token: token === 'Any' ? data.token : undefined,

--- a/src/features/listings/components/SubmissionsPage/SubmissionTable.tsx
+++ b/src/features/listings/components/SubmissionsPage/SubmissionTable.tsx
@@ -298,6 +298,11 @@ export const SubmissionTable = ({
             const statusB = sponsorshipSubmissionStatus(b);
             return statusA.localeCompare(statusB) * factor;
 
+          case 'submissionTitle':
+            const submissionTitleA = submissionTitle(a) || '';
+            const submissionTitleB = submissionTitle(b) || '';
+            return submissionTitleA.localeCompare(submissionTitleB) * factor;
+
           default:
             return 0;
         }
@@ -768,6 +773,9 @@ export const SubmissionTable = ({
                                               `Milestone ${milestone.milestoneIndex}`}
                                           </p>
                                         </TableCell>
+                                      )}
+                                      {visibleColumns.submissionTitle && (
+                                        <TableCell />
                                       )}
                                       {visibleColumns.ask && (
                                         <TableCell>

--- a/src/features/listings/components/SubmissionsPage/SubmissionTable.tsx
+++ b/src/features/listings/components/SubmissionsPage/SubmissionTable.tsx
@@ -54,6 +54,7 @@ import { getSubmissionUrl } from '@/utils/bounty-urls';
 import { cn } from '@/utils/cn';
 import { dayjs } from '@/utils/dayjs';
 import { getMilestoneStatus } from '@/utils/milestone-helpers';
+import { nthLabelGenerator } from '@/utils/rank';
 
 import {
   parseHtml,
@@ -93,6 +94,24 @@ export const sponsorshipSubmissionStatus = (submission: SubmissionWithUser) => {
     return 'InProgress';
   if (submission.status !== 'Pending') return submission.status;
   return submission.label;
+};
+
+export const submissionTitle = (submission: SubmissionWithUser) => {
+  switch (submission.listing?.type) {
+    case 'sponsorship':
+      return submission.title || 'N/A';
+    case 'bounty':
+      if (submission.winnerPosition) {
+        let label = nthLabelGenerator(submission.winnerPosition, false);
+        label = label.charAt(0).toUpperCase() + label.slice(1);
+        return `${label} Place`;
+      }
+      return 'N/A';
+    case 'project':
+      return submission.listing.title;
+    default:
+      return '';
+  }
 };
 
 const thClassName =
@@ -293,6 +312,7 @@ export const SubmissionTable = ({
   type ColumnKey =
     | (typeof eligibilityColumnKeys)[number]
     | 'submission'
+    | 'submissionTitle'
     | 'ask'
     | 'status'
     | 'community';
@@ -300,6 +320,7 @@ export const SubmissionTable = ({
   const defaultVisibleColumns = useMemo<Record<ColumnKey, boolean>>(() => {
     const base: Record<ColumnKey, boolean> = {
       submission: true,
+      submissionTitle: true,
       ask: true,
       status: true,
       community: true,
@@ -341,6 +362,7 @@ export const SubmissionTable = ({
 
   const getColumnLabel = (key: ColumnKey) => {
     if (key === 'submission') return 'Submission';
+    if (key === 'submissionTitle') return 'Submission Title';
     if (key === 'ask')
       return bounty.compensationType === 'fixed' ? 'Reward' : 'Ask';
     if (key === 'status') return 'Status';
@@ -365,6 +387,10 @@ export const SubmissionTable = ({
   >(
     () => [
       { key: 'submission' as ColumnKey, label: getColumnLabel('submission') },
+      {
+        key: 'submissionTitle' as ColumnKey,
+        label: getColumnLabel('submissionTitle'),
+      },
       { key: 'ask' as ColumnKey, label: getColumnLabel('ask') },
       { key: 'status' as ColumnKey, label: getColumnLabel('status') },
       ...eligibilityColumnKeys.map((k) => ({
@@ -422,6 +448,16 @@ export const SubmissionTable = ({
                       {getColumnLabel('submission')}
                     </SortableTH>
                   )}
+                  {visibleColumns.submissionTitle && (
+                    <SortableTH
+                      column="submissionTitle"
+                      currentSort={currentSort}
+                      setSort={onSort}
+                      className={cn(thClassName)}
+                    >
+                      {getColumnLabel('submissionTitle')}
+                    </SortableTH>
+                  )}
                   {visibleColumns.ask && (
                     <SortableTH
                       column="ask"
@@ -467,6 +503,10 @@ export const SubmissionTable = ({
                     const submissionStatus =
                       sponsorshipSubmissionStatus(submission);
                     const submissionLink = getSubmissionUrl(submission, bounty);
+                    const submissionTitleText = submissionTitle({
+                      ...submission,
+                      listing: bounty,
+                    });
                     const token = isUsdBased ? submission.token : bounty.token;
                     const tokenObject = tokenList.filter(
                       (e) => e?.tokenSymbol === token,
@@ -528,6 +568,13 @@ export const SubmissionTable = ({
                                     </p>
                                   </div>
                                 </Link>
+                              </TableCell>
+                            )}
+                            {visibleColumns.submissionTitle && (
+                              <TableCell className="min-w-[200px] pr-0">
+                                <p className="whitespace-nowrap text-sm font-medium text-slate-700">
+                                  {submissionTitleText}
+                                </p>
                               </TableCell>
                             )}
                             {visibleColumns.ask && (

--- a/src/features/listings/utils/submissionFormSchema.ts
+++ b/src/features/listings/utils/submissionFormSchema.ts
@@ -26,6 +26,16 @@ const submissionSchema = (
           z.string().trim().regex(URL_REGEX, 'Invalid URL'),
         ])
         .optional(),
+      title: z
+        .union([
+          z.literal(''),
+          z
+            .string()
+            .trim()
+            .min(1, 'Required')
+            .max(255, 'Title must be less than 255 characters'),
+        ])
+        .optional(),
       otherInfo: z.string().optional(),
       otherTokenDetails: z.string().optional(),
       ask: z.union([z.number().int().min(1), z.null()]).optional(),

--- a/src/features/listings/utils/submissionFormSchema.ts
+++ b/src/features/listings/utils/submissionFormSchema.ts
@@ -87,6 +87,16 @@ const submissionSchema = (
         });
       }
       if (
+        listing.type === 'sponsorship' &&
+        (!data.title || data.title.trim().length === 0)
+      ) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['title'],
+          message: 'Title is required',
+        });
+      }
+      if (
         (listing.type === 'project' || listing.type === 'sponsorship') &&
         listing.compensationType !== 'fixed'
       ) {

--- a/src/features/logging/types/event-data.ts
+++ b/src/features/logging/types/event-data.ts
@@ -172,6 +172,7 @@ export interface ListingFieldValueMap {
 export type SubmissionEditableFields =
   | 'link'
   | 'tweet'
+  | 'title'
   | 'otherInfo'
   | 'eligibilityAnswers'
   | 'ask'
@@ -189,6 +190,7 @@ export type PlatformAdminEditableSubmissionFields = 'status' | 'paymentDetails';
 export interface SubmissionFieldValueMap {
   link: string | null;
   tweet: string | null;
+  title: string | null;
   otherInfo: string | null;
   eligibilityAnswers: JsonValue | null;
   ask: number | null;
@@ -592,6 +594,7 @@ export function detectSubmissionChanges(
 
   const fields: SubmissionEditableFields[] = [
     'link',
+    'title',
     'tweet',
     'otherInfo',
     'eligibilityAnswers',

--- a/src/features/sponsor-dashboard/components/SubmissionTable.tsx
+++ b/src/features/sponsor-dashboard/components/SubmissionTable.tsx
@@ -849,6 +849,7 @@ export const SubmissionTable = ({
                                   </TableCell>
                                 </>
                               )}
+                              {visibleColumns.submissionTitle && <TableCell />}
                               {visibleColumns.ask && (
                                 <TableCell>
                                   <div className="flex w-full items-center overflow-visible">

--- a/src/features/sponsor-dashboard/components/SubmissionTable.tsx
+++ b/src/features/sponsor-dashboard/components/SubmissionTable.tsx
@@ -64,7 +64,10 @@ import { getMilestoneStatus } from '@/utils/milestone-helpers';
 import { truncatePublicKey } from '@/utils/truncatePublicKey';
 
 import { SubmissionDrawer } from '@/features/listings/components/Submission/SubmissionDrawer';
-import { sponsorshipSubmissionStatus } from '@/features/listings/components/SubmissionsPage/SubmissionTable';
+import {
+  sponsorshipSubmissionStatus,
+  submissionTitle,
+} from '@/features/listings/components/SubmissionsPage/SubmissionTable';
 import { getListingIcon } from '@/features/listings/utils/getListingIcon';
 import { getListingTypeLabel } from '@/features/listings/utils/status';
 import { ActivityHistoryMinified } from '@/features/logging/components/ActivityHistoryMinified';
@@ -99,6 +102,7 @@ const thClassName =
 type ColumnKey =
   | 'contributor'
   | 'title'
+  | 'submissionTitle'
   | 'ask'
   | 'status'
   | 'dates'
@@ -108,6 +112,7 @@ type ColumnKey =
 const columnLabels: Record<ColumnKey, string> = {
   contributor: 'Contributor',
   title: 'Listing Name',
+  submissionTitle: 'Submission Title',
   ask: 'Ask',
   status: 'Status',
   dates: 'Dates',
@@ -187,6 +192,7 @@ export const SubmissionTable = ({
   const defaultVisibleColumns: Record<ColumnKey, boolean> = {
     contributor: true,
     title: true,
+    submissionTitle: true,
     ask: true,
     status: true,
     dates: true,
@@ -296,6 +302,16 @@ export const SubmissionTable = ({
                     Listing Name
                   </SortableTH>
                 </>
+              )}
+              {visibleColumns.submissionTitle && (
+                <SortableTH
+                  column="submissionTitle"
+                  currentSort={currentSort}
+                  setSort={onSort}
+                  className={cn(thClassName)}
+                >
+                  Submission Title
+                </SortableTH>
               )}
               {visibleColumns.ask && <SubmissionTh>Ask</SubmissionTh>}
               {visibleColumns.status && (
@@ -419,6 +435,7 @@ export const SubmissionTable = ({
                   ? dayjs(submission?.approveDate).format("DD MMM'YY")
                   : '';
               const listingStatus = sponsorshipSubmissionStatus(submission);
+              const submissionTitleText = submissionTitle(submission);
               const submissionLink = getSubmissionUrl(
                 submission,
                 submission?.listing,
@@ -532,6 +549,11 @@ export const SubmissionTable = ({
                             </Link>
                           </TableCell>
                         </>
+                      )}
+                      {visibleColumns.submissionTitle && (
+                        <TableCell className="h-full max-w-80 whitespace-normal break-words py-2 font-medium text-slate-700">
+                          <p className="h-full w-full">{submissionTitleText}</p>
+                        </TableCell>
                       )}
                       {visibleColumns.ask && (
                         <TableCell

--- a/src/features/sponsor-dashboard/components/Submissions/Details.tsx
+++ b/src/features/sponsor-dashboard/components/Submissions/Details.tsx
@@ -78,6 +78,12 @@ export const Details = ({
             />
           </>
         )}
+        {isSponsorship && (
+          <InfoBox
+            label="Submission Title"
+            content={selectedSubmission?.title || ''}
+          />
+        )}
         {selectedSubmission?.eligibilityAnswers &&
           selectedSubmission.eligibilityAnswers.map(
             (answer: any, i: number) => {

--- a/src/interface/submission.ts
+++ b/src/interface/submission.ts
@@ -38,6 +38,7 @@ interface SubmissionWithUser {
   status: SubmissionStatus | 'Deleted';
   link?: string;
   tweet?: string;
+  title?: string;
   otherInfo?: string;
   otherTokenDetails?: string;
   eligibilityAnswers?: any;

--- a/src/pages/api/submission/create.ts
+++ b/src/pages/api/submission/create.ts
@@ -116,6 +116,7 @@ async function submission(req: NextApiRequestWithUser, res: NextApiResponse) {
     listingId,
     link,
     tweet,
+    title,
     otherInfo,
     eligibilityAnswers,
     ask,
@@ -147,6 +148,7 @@ async function submission(req: NextApiRequestWithUser, res: NextApiResponse) {
       {
         link,
         tweet,
+        title,
         otherInfo,
         eligibilityAnswers,
         ask,

--- a/src/pages/api/submission/create.ts
+++ b/src/pages/api/submission/create.ts
@@ -80,6 +80,7 @@ async function createSubmission(
       listingId,
       link: validatedData.link || '',
       tweet: validatedData.tweet || '',
+      title: validatedData.title || '',
       otherInfo: validatedData.otherInfo || '',
       eligibilityAnswers: validatedData.eligibilityAnswers || [],
       ask: validatedData.ask || null,

--- a/src/pages/api/submission/update.ts
+++ b/src/pages/api/submission/update.ts
@@ -84,6 +84,7 @@ async function updateSubmission(
   const formattedData = {
     link: validatedData.link || '',
     tweet: validatedData.tweet || '',
+    title: validatedData.title || '',
     otherInfo: validatedData.otherInfo || '',
     eligibilityAnswers: validatedData.eligibilityAnswers || [],
     ask: validatedData.ask || 0,

--- a/src/pages/dashboard/submissions/index.tsx
+++ b/src/pages/dashboard/submissions/index.tsx
@@ -31,7 +31,10 @@ import { api } from '@/lib/api';
 import { useUser } from '@/store/user';
 import { cn } from '@/utils/cn';
 
-import { sponsorshipSubmissionStatus } from '@/features/listings/components/SubmissionsPage/SubmissionTable';
+import {
+  sponsorshipSubmissionStatus,
+  submissionTitle,
+} from '@/features/listings/components/SubmissionsPage/SubmissionTable';
 import { Banner } from '@/features/sponsor-dashboard/components/Banner';
 import { CreateListingModal } from '@/features/sponsor-dashboard/components/CreateListingModal';
 import {
@@ -165,6 +168,11 @@ export default function SponsorListings() {
             const titleA = a.listing.title || '';
             const titleB = b.listing.title || '';
             return titleA.localeCompare(titleB) * factor;
+
+          case 'submissionTitle':
+            const submissionTitleA = submissionTitle(a) || '';
+            const submissionTitleB = submissionTitle(b) || '';
+            return submissionTitleA.localeCompare(submissionTitleB) * factor;
 
           case 'submittedBy':
             const authorA = a.user.name || '';


### PR DESCRIPTION
@race-of-sloths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `title` to sponsorship submissions and surfaces it end-to-end (DB, validation, APIs, tables, details, sorting/display).
> 
> - **DB/Schema**
>   - Add `Submission.title` (`VARCHAR(255)`) via migration and Prisma model.
> - **Validation/API**
>   - Require `title` for `sponsorship` in `submissionFormSchema`; pass through create/update API handlers.
> - **Types/Logging**
>   - Extend `SubmissionWithUser`, editable fields, and change detection to include `title`.
> - **UI – Submission Form**
>   - Add required `Title` field for sponsorship submissions in `EligibilityQuestionsForm` and plumb in `SubmissionDrawer` (load/reset/submit).
> - **UI – Tables/Details**
>   - Introduce `submissionTitle()` helper.
>   - Add "Submission Title" column (visible by default) with sorting in:
>     - `SubmissionsPage/SubmissionTable` (public listing view)
>     - Sponsor dashboard `SubmissionTable` and page; display in Details panel.
>   - Show title for sponsorships; for bounties show winner place; for projects use listing title.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af298a060b270c52ca4ff02f1999c1ac090660b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->