### PR TITLE
feat: fallback to eligibility question if submission title is not available

### DIFF
--- a/src/features/listings/components/SubmissionsPage/SubmissionTable.tsx
+++ b/src/features/listings/components/SubmissionsPage/SubmissionTable.tsx
@@ -99,7 +99,17 @@ export const sponsorshipSubmissionStatus = (submission: SubmissionWithUser) => {
 export const submissionTitle = (submission: SubmissionWithUser) => {
   switch (submission.listing?.type) {
     case 'sponsorship':
-      return submission.title || 'N/A';
+      if (submission.title) {
+        return submission.title;
+      }
+      const eligibilityAnswer = submission.eligibilityAnswers?.find(
+        (answer: { question: string; answer: string }) =>
+          answer?.question?.toLowerCase().trim() === 'title',
+      );
+      if (eligibilityAnswer) {
+        return eligibilityAnswer.answer;
+      }
+      return 'N/A';
     case 'bounty':
       if (submission.winnerPosition) {
         let label = nthLabelGenerator(submission.winnerPosition, false);
@@ -578,7 +588,7 @@ export const SubmissionTable = ({
                             {visibleColumns.submissionTitle && (
                               <TableCell className="min-w-[200px] pr-0">
                                 <p className="whitespace-nowrap text-sm font-medium text-slate-700">
-                                  {submissionTitleText}
+                                  {parseHtml(submissionTitleText, tableOptions)}
                                 </p>
                               </TableCell>
                             )}

--- a/src/features/sponsor-dashboard/components/SubmissionTable.tsx
+++ b/src/features/sponsor-dashboard/components/SubmissionTable.tsx
@@ -75,6 +75,7 @@ import { EarnAvatar } from '@/features/talent/components/EarnAvatar';
 
 import { type SubmissionWithListingUser } from '../queries/dashboard-submissions';
 import { colorMap } from '../utils/statusColorMap';
+import { parseHtml, tableOptions } from './InfoBox';
 import { ListingTh } from './ListingTable';
 import MilestoneCompletionLine from './Milestones/CompletionLine';
 import MilestoneActionButton from './Milestones/MilestoneActionButton';
@@ -552,7 +553,9 @@ export const SubmissionTable = ({
                       )}
                       {visibleColumns.submissionTitle && (
                         <TableCell className="h-full max-w-80 whitespace-normal break-words py-2 font-medium text-slate-700">
-                          <p className="h-full w-full">{submissionTitleText}</p>
+                          <p className="h-full w-full">
+                            {parseHtml(submissionTitleText, tableOptions)}
+                          </p>
                         </TableCell>
                       )}
                       {visibleColumns.ask && (

--- a/src/features/sponsor-dashboard/components/Submissions/Details.tsx
+++ b/src/features/sponsor-dashboard/components/Submissions/Details.tsx
@@ -78,10 +78,10 @@ export const Details = ({
             />
           </>
         )}
-        {isSponsorship && (
+        {isSponsorship && !!selectedSubmission?.title && (
           <InfoBox
             label="Submission Title"
-            content={selectedSubmission?.title || ''}
+            content={selectedSubmission.title}
           />
         )}
         {selectedSubmission?.eligibilityAnswers &&


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sponsorship submission titles now fall back to the 'title' eligibility answer and are rendered as parsed HTML in tables; Details shows the title only when present.
> 
> - **Listings/Submissions**:
>   - `submissionTitle` now falls back to the `eligibilityAnswers` entry with question `title` when `submission.title` is missing.
>   - Render `submissionTitle` via `parseHtml(...)` in `SubmissionTable`.
> - **Sponsor Dashboard**:
>   - Render submission titles via `parseHtml(...)` in `SubmissionTable`.
>   - Show "Submission Title" in Details only if a title exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 774eab99776a5130a40efc86d2d48e22a094cfde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->